### PR TITLE
Implement relative times for posts to see how long ago a post was made.

### DIFF
--- a/app/templates/gallery.html
+++ b/app/templates/gallery.html
@@ -98,7 +98,7 @@
         <div class="card-footer d-flex justify-content-between align-items-center">
           <div>
             <h5 class="card-title">Post by {{ submission.author.username }}</h5>
-            <p class="card-text">{{ submission.timestamp.strftime('%Y-%m-%d %H:%M:%S') }}</p>
+            <p class="card-text">Posted {{ submission.relative_timestamp }}</p>
           </div>
           <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#codeModal{{ submission.id }}">
             &lt;&gt; Get this code

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ flask-wtf
 flask-migrate
 werkzeug
 elasticsearch
+humanize


### PR DESCRIPTION
Instead of simple printing the raw timestamp in the card for each post, we now display how long ago that particular post was made.

This is a QOL improvement for users.

Updated `requirements.txt` to include `humanize` dependency